### PR TITLE
ci: update tests for aali-graphdb client

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -47,13 +47,39 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
+      - run: go test $(go list ./pkg/... | grep -v 'aali_graphdb')  # run all the tests except for those in aali_graphdb (those are run below in separate job)
+
+  get-test-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      IMAGE_NAMES: ${{ env.IMAGE_NAMES }}
+    steps:
+      - if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: echo "IMAGE_NAMES=[\"${{ inputs.image_name }}\"]" | tee "$GITHUB_ENV"
+      - if: ${{ github.event_name != 'workflow_dispatch' }}
+        run: echo "IMAGE_NAMES=[\"ghcr.io/ansys/aali-graphdb:edge\", \"ghcr.io/ansys/aali-graphdb:latest\", \"ghcr.io/ansys/aali-graphdb:v1.0.0\"]" | tee "$GITHUB_ENV"
+
+  graphdb-client-unit-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        image-name:
+          - ghcr.io/ansys/aali-graphdb:edge
+          - ghcr.io/ansys/aali-graphdb:latest
+          - ghcr.io/ansys/aali-graphdb:v1.0.0
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
       - uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ secrets.PYANSYS_CI_BOT_USERNAME }}
           password: ${{ secrets.PYANSYS_CI_BOT_PACKAGE_TOKEN }}
-      - run: docker pull ghcr.io/ansys/aali-graphdb:edge
-      - run: go test -v ./pkg/...
+      - run: docker pull ${{ matrix.image-name }}
+      - run: go test -v ./pkg/aali_graphdb/... -imagename ${{ matrix.image-name }}
 
   build:
     name: Build project
@@ -198,7 +224,7 @@ jobs:
   release:
     name: Generate GitHub release
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
-    needs: [doc-api-reference, build, unit-tests]
+    needs: [doc-api-reference, build, unit-tests, graphdb-client-unit-tests]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/pkg/aali_graphdb/client_test.go
+++ b/pkg/aali_graphdb/client_test.go
@@ -28,6 +28,7 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
+	"regexp"
 	"testing"
 	"time"
 
@@ -406,17 +407,17 @@ func TestErrorsReturned(t *testing.T) {
 	require.NoError(t, err)
 
 	query := "not a real cypher query"
-	expected := `unexpected status code: 500 "Query execution failed: Parser exception: extraneous input 'not' expecting {ALTER, ATTACH, BEGIN, CALL, CHECKPOINT, COMMENT, COMMIT, COPY, CREATE, DELETE, DETACH, DROP, EXPLAIN, EXPORT, IMPORT, INSTALL, LOAD, MATCH, MERGE, OPTIONAL, PROFILE, RETURN, ROLLBACK, SET, UNWIND, USE, WITH, SP} (line: 1, offset: 0)\n\"not a real cypher query\"\n ^^^"`
+	pat := regexp.MustCompile(`Query execution failed:[\s\S]*` + query)
 
 	t.Run("Read", func(t *testing.T) {
 		_, err = client.CypherQueryRead(DBNAME, query, nil)
 		require.Error(t, err)
-		assert.Equal(t, expected, fmt.Sprint(err))
+		assert.True(t, pat.MatchString(fmt.Sprint(err)))
 	})
 	t.Run("Write", func(t *testing.T) {
 		_, err = client.CypherQueryWrite(DBNAME, query, nil)
 		require.Error(t, err)
-		assert.Equal(t, expected, fmt.Sprint(err))
+		assert.True(t, pat.MatchString(fmt.Sprint(err)))
 	})
 }
 


### PR DESCRIPTION
Port over necessary changes from https://github.com/ansys/aali-graphdb-goclient/pull/27

1. Make error message test less strict so it doesn't break when kuzu is updated
2. Run the aali-graphdb tests on a matrix of server versions so we better ensure backwards compatibility