### PR TITLE
feat: graphdb client export/import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ doc/source/api_reference/logging/
 doc/source/api_reference/sharedtypes/
 doc/source/api_reference/type_definitions/
 doc/source/api_reference/typeconverters/
+
+# env
+.env

--- a/pkg/aali_graphdb/client.go
+++ b/pkg/aali_graphdb/client.go
@@ -29,6 +29,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 
 	"github.com/ansys/aali-sharedtypes/pkg/clients"
 	"go.uber.org/zap"
@@ -344,4 +345,88 @@ type Parameters interface {
 
 func (params ParameterMap) AsParameters() (map[string]Value, error) {
 	return params, nil
+}
+
+type aaliGraphDbExportOpts struct {
+	Format      string `json:"format,omitempty"`
+	Compression string `json:"compression,omitempty"`
+}
+
+type AaliGraphDbExportOpt interface {
+	apply(*aaliGraphDbExportOpts)
+}
+
+type WithFormatParquet struct{}
+
+func (WithFormatParquet) apply(opts *aaliGraphDbExportOpts) {
+	opts.Format = "parquet"
+}
+
+type WithFormatCsv struct{}
+
+func (WithFormatCsv) apply(opts *aaliGraphDbExportOpts) {
+	opts.Format = "csv"
+}
+
+type WithCompressionDefault struct{}
+
+func (WithCompressionDefault) apply(opts *aaliGraphDbExportOpts) {
+	opts.Compression = "default"
+}
+
+type WithCompressionFast struct{}
+
+func (WithCompressionFast) apply(opts *aaliGraphDbExportOpts) {
+	opts.Compression = "fast"
+}
+
+type WithCompressionBest struct{}
+
+func (WithCompressionBest) apply(opts *aaliGraphDbExportOpts) {
+	opts.Compression = "best"
+}
+
+func (client *Client) ExportDatabase(name string, file string, opts ...AaliGraphDbExportOpt) error {
+	exportOpts := &aaliGraphDbExportOpts{}
+	for _, opt := range opts {
+		opt.apply(exportOpts)
+	}
+
+	out, err := os.Create(file)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		err := out.Close()
+		if err != nil {
+			client.logger.Warn(fmt.Sprintf("could not close file %q: %s", file, err))
+		}
+	}()
+
+	u, err := url.JoinPath(client.address, "databases", name, "export")
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.post(u, exportOpts)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if e := resp.Body.Close(); e != nil {
+			client.logger.Warn("could not close body")
+		}
+	}()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		bodyBytes, _ := io.ReadAll(resp.Body)
+		body := string(bodyBytes)
+		return fmt.Errorf("unexpected status code: %v %q", resp.StatusCode, body)
+	}
+
+	_, err = io.Copy(out, resp.Body)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/pkg/aali_graphdb/client.go
+++ b/pkg/aali_graphdb/client.go
@@ -27,6 +27,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"mime/multipart"
 	"net/http"
 	"net/url"
 	"os"
@@ -426,6 +427,62 @@ func (client *Client) ExportDatabase(name string, file string, opts ...AaliGraph
 	_, err = io.Copy(out, resp.Body)
 	if err != nil {
 		return err
+	}
+
+	return nil
+}
+
+func (client *Client) ImportDatabase(name string, filepath string) error {
+	file, err := os.Open(filepath)
+	if err != nil {
+		return nil
+	}
+	defer func() {
+		err := file.Close()
+		if err != nil {
+			client.logger.Warn(fmt.Sprintf("could not close file %q: %s", filepath, err))
+		}
+	}()
+
+	u, err := url.JoinPath(client.address, "databases", name, "import")
+	if err != nil {
+		return err
+	}
+
+	var b bytes.Buffer
+	w := multipart.NewWriter(&b)
+	fw, err := w.CreateFormFile("file", file.Name())
+	if err != nil {
+		return err
+	}
+	if _, err = io.Copy(fw, file); err != nil {
+		return nil
+	}
+	if err = w.Close(); err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, u, &b)
+	if err != nil {
+		return err
+	}
+	if client.apiKey != "" {
+		req.Header.Set("api-key", client.apiKey)
+	}
+	req.Header.Set("Content-Type", w.FormDataContentType())
+	resp, err := client.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if e := resp.Body.Close(); e != nil {
+			client.logger.Warn("could not close body")
+		}
+	}()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		bodyBytes, _ := io.ReadAll(resp.Body)
+		body := string(bodyBytes)
+		return fmt.Errorf("unexpected status code: %v %q", resp.StatusCode, body)
 	}
 
 	return nil

--- a/pkg/aali_graphdb/client_test.go
+++ b/pkg/aali_graphdb/client_test.go
@@ -580,3 +580,43 @@ func extractTarGz(r io.Reader, dir string) error {
 	}
 	return nil
 }
+
+func TestImport(t *testing.T) {
+	client := getTestClient(t)
+
+	// make a seed DB that an export can be made from
+	const SeedDb = "seeder"
+	require.NoError(t, client.CreateDatabase(SeedDb))
+	for _, query := range []string{
+		"CREATE NODE TABLE User(name STRING, age INT64, PRIMARY KEY (name))",
+		"CREATE (:User {name: 'Adam', age: 30});",
+		"CREATE (:User {name: 'Karissa', age: 40});",
+		"CREATE (:User {name: 'Zhang', age: 50});",
+		"CREATE (:User {name: 'Noura', age: 25});",
+	} {
+		_, err := client.CypherQueryWrite(SeedDb, query, nil)
+		require.NoError(t, err)
+	}
+
+	for name, format := range map[string]AaliGraphDbExportOpt{
+		"Parquet": WithFormatParquet{},
+		"Csv":     WithFormatCsv{},
+	} {
+		t.Run(name, func(t *testing.T) {
+			tmpdir := t.TempDir()
+			export := path.Join(tmpdir, "export.tar.gz")
+			require.NoError(t, client.ExportDatabase(SeedDb, export, format))
+
+			require.NoError(t, client.CreateDatabase(name))
+			resBefore, err := client.CypherQueryRead(name, "MATCH (u) RETURN COUNT(*) AS count;", nil)
+			require.NoError(t, err)
+			require.Equal(t, 0., resBefore[0]["count"])
+
+			require.NoError(t, client.ImportDatabase(name, export))
+			resAfter, err := client.CypherQueryRead(name, "MATCH (u) RETURN COUNT(*) AS count;", nil)
+			require.NoError(t, err)
+			assert.Equal(t, 4., resAfter[0]["count"])
+		})
+	}
+
+}

--- a/pkg/aali_graphdb/client_test.go
+++ b/pkg/aali_graphdb/client_test.go
@@ -23,11 +23,16 @@
 package aali_graphdb
 
 import (
+	"archive/tar"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
+	"io"
 	"net/http"
+	"os"
+	"path"
 	"regexp"
 	"testing"
 	"time"
@@ -480,4 +485,98 @@ func TestRequiresApiKey(t *testing.T) {
 	// try to make a call without api key and make sure you get an error
 	_, err = client.WithApiKey("").GetDatabases()
 	assert.EqualError(err, "unexpected status code: 401")
+}
+
+func TestExport(t *testing.T) {
+	client := getTestClient(t)
+
+	const Db = "test-db"
+	require.NoError(t, client.CreateDatabase(Db))
+
+	// put some data in there
+	for _, query := range []string{
+		"CREATE NODE TABLE User(name STRING, age INT64, PRIMARY KEY (name))",
+		"CREATE (:User {name: 'Adam', age: 30});",
+		"CREATE (:User {name: 'Karissa', age: 40});",
+		"CREATE (:User {name: 'Zhang', age: 50});",
+		"CREATE (:User {name: 'Noura', age: 25});",
+	} {
+		_, err := client.CypherQueryWrite(Db, query, nil)
+		require.NoError(t, err)
+	}
+
+	testCases := map[string]struct {
+		opts []AaliGraphDbExportOpt
+		ext  string
+	}{
+		"NoOpts":             {[]AaliGraphDbExportOpt{}, "parquet"},
+		"Parquet":            {[]AaliGraphDbExportOpt{WithFormatParquet{}}, "parquet"},
+		"Csv":                {[]AaliGraphDbExportOpt{WithFormatCsv{}}, "csv"},
+		"DefaultCompression": {[]AaliGraphDbExportOpt{WithCompressionDefault{}}, "parquet"},
+		"BestCompression":    {[]AaliGraphDbExportOpt{WithCompressionBest{}}, "parquet"},
+		"FastCompression":    {[]AaliGraphDbExportOpt{WithCompressionFast{}}, "parquet"},
+		"ParquetBest":        {[]AaliGraphDbExportOpt{WithFormatParquet{}, WithCompressionBest{}}, "parquet"},
+		"CsvFast":            {[]AaliGraphDbExportOpt{WithCompressionFast{}, WithFormatCsv{}}, "csv"},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			tmpdir := t.TempDir()
+			exportFile := path.Join(tmpdir, "export.tar.gz")
+			require.NoFileExists(t, exportFile)
+			require.NoError(t, client.ExportDatabase(Db, exportFile, tc.opts...))
+			assert.FileExists(t, exportFile)
+
+			unarchivedPath := path.Join(tmpdir, "unarchived")
+			require.NoError(t, os.Mkdir(unarchivedPath, os.ModePerm))
+			archive, err := os.Open(exportFile)
+			require.NoError(t, err)
+			defer func() { _ = archive.Close() }()
+			require.NoError(t, extractTarGz(archive, unarchivedPath))
+
+			exportDir := path.Join(unarchivedPath, "aali-graphdb-export")
+			assert.DirExists(t, exportDir)
+			assert.FileExists(t, path.Join(exportDir, "copy.cypher"))
+			assert.FileExists(t, path.Join(exportDir, "schema.cypher"))
+			assert.FileExists(t, path.Join(exportDir, "index.cypher"))
+			assert.FileExists(t, path.Join(exportDir, fmt.Sprintf("User.%s", tc.ext)))
+		})
+	}
+}
+
+func extractTarGz(r io.Reader, dir string) error {
+	gzipReader, err := gzip.NewReader(r)
+	if err != nil {
+		return err
+	}
+
+	tarReader := tar.NewReader(gzipReader)
+	for {
+		header, err := tarReader.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+
+		dstPath := path.Join(dir, header.Name)
+		switch header.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(dstPath, header.FileInfo().Mode().Perm()); err != nil {
+				return err
+			}
+		case tar.TypeReg:
+			dst, err := os.OpenFile(dstPath, os.O_CREATE|os.O_RDWR, header.FileInfo().Mode())
+			if err != nil {
+				return err
+			}
+			defer func() { _ = dst.Close() }()
+
+			_, err = io.Copy(dst, tarReader)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
This has been a feature of `aali-graphdb` for a long time, but never integrated into the client. It will become necessary in order to support `aali-graphdb` in [`data-shield`](https://github.com/ansys-internal/data-shield).