### PR TITLE
feat: generalize aali-graphdb import/export methods

### DIFF
--- a/internal/gen/logical_type/logical_type.gotmpl
+++ b/internal/gen/logical_type/logical_type.gotmpl
@@ -119,7 +119,7 @@ func newLogicalTypeHelper(lt LogicalType) logicalTypeUnmarshalHelper {
 func getTwopleLogicalTypeFromHelper(tups []Twople[string, logicalTypeUnmarshalHelper]) []Twople[string, LogicalType] {
 	ltTups := make([]Twople[string, LogicalType], len(tups))
 	for i, tup := range tups {
-		newTup := Twople[string, LogicalType]{tup.a, tup.b.LogicalType}
+		newTup := Twople[string, LogicalType]{tup.A, tup.B.LogicalType}
 		ltTups[i] = newTup
 	}
 	return ltTups

--- a/pkg/aali_graphdb/client.go
+++ b/pkg/aali_graphdb/client.go
@@ -283,6 +283,42 @@ func (client Client) DeleteDatabase(name string) error {
 	return nil
 }
 
+const getSchemaMinVer = "v1.2.14"
+
+func (client Client) GetSchema(name string) (string, error) {
+	ver, err := client.GetVersion()
+	if err != nil {
+		return "", err
+	}
+	if semverComp(ver.Version, getSchemaMinVer) < 0 {
+		return "", fmt.Errorf("the `GET /databases/{name}/schema` endpoint was introduced in %s, but the current server is %s", createDbPutMinVer, ver.Version)
+	}
+
+	url, err := url.JoinPath(client.address, "databases", name, "schema")
+	if err != nil {
+		return "", err
+	}
+	resp, err := client.get(url)
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		if e := resp.Body.Close(); e != nil {
+			client.logger.Warn("could not close body")
+		}
+	}()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", fmt.Errorf("unexpected status code: %v", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	return string(body), nil
+}
+
 type cypherQueryResponse[T any] struct {
 	Result []T `json:"result"`
 }

--- a/pkg/aali_graphdb/client.go
+++ b/pkg/aali_graphdb/client.go
@@ -30,9 +30,11 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/ansys/aali-sharedtypes/pkg/clients"
 	"go.uber.org/zap"
+	"golang.org/x/mod/semver"
 )
 
 type Client struct {
@@ -185,13 +187,60 @@ func (client Client) GetDatabases() ([]string, error) {
 	return r.Databases, nil
 }
 
+const createDbPutMinVer = "v1.2.14"
+
 func (client Client) CreateDatabase(name string) error {
+	ver, err := client.GetVersion()
+	if err != nil {
+		return err
+	}
+
+	if semverComp(ver.Version, createDbPutMinVer) >= 0 {
+		return client.createDatabasePut(name)
+	} else {
+		return client.createDatabasePost(name)
+	}
+}
+
+func (client Client) createDatabasePost(name string) error {
+	client.logger.Warn("The `POST /databases` method for creating a new DB is deprecated. Upgrade your aali-graphdb server to use the newer `PUT /databases/{name}` method")
+
 	u, err := url.JoinPath(client.address, "databases")
 	if err != nil {
 		return err
 	}
 
 	resp, err := client.post(u, map[string]any{"name": name, "in_memory": false})
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if e := resp.Body.Close(); e != nil {
+			client.logger.Warn("could not close body")
+		}
+	}()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("unexpected status code: %v", resp.StatusCode)
+	}
+
+	return nil
+}
+
+func (client Client) createDatabasePut(name string) error {
+	u, err := url.JoinPath(client.address, "databases", name)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest(http.MethodPut, u, nil)
+	if err != nil {
+		return err
+	}
+	if client.apiKey != "" {
+		req.Header.Set("api-key", client.apiKey)
+	}
+
+	resp, err := client.httpClient.Do(req)
 	if err != nil {
 		return err
 	}
@@ -463,4 +512,18 @@ func (client *Client) ImportDatabase(name string, src io.Reader) error {
 	}
 
 	return nil
+}
+
+// A helper method for comparing semvers.
+//
+// It does the same thing as [semver.Compare], excepts it prepends a "v" prefix if the provided versions don't have them.
+// This is since Go's semver requires `v*` even though that's not really part of the semver spec.
+func semverComp(v string, w string) int {
+	if !strings.HasPrefix(v, "v") {
+		v = fmt.Sprintf("v%s", v)
+	}
+	if !strings.HasPrefix(w, "v") {
+		w = fmt.Sprintf("v%s", w)
+	}
+	return semver.Compare(v, w)
 }

--- a/pkg/aali_graphdb/client.go
+++ b/pkg/aali_graphdb/client.go
@@ -30,7 +30,6 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/url"
-	"os"
 
 	"github.com/ansys/aali-sharedtypes/pkg/clients"
 	"go.uber.org/zap"
@@ -387,22 +386,11 @@ func (WithCompressionBest) apply(opts *aaliGraphDbExportOpts) {
 	opts.Compression = "best"
 }
 
-func (client *Client) ExportDatabase(name string, file string, opts ...AaliGraphDbExportOpt) error {
+func (client *Client) ExportDatabase(name string, dst io.Writer, opts ...AaliGraphDbExportOpt) error {
 	exportOpts := &aaliGraphDbExportOpts{}
 	for _, opt := range opts {
 		opt.apply(exportOpts)
 	}
-
-	out, err := os.Create(file)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		err := out.Close()
-		if err != nil {
-			client.logger.Warn(fmt.Sprintf("could not close file %q: %s", file, err))
-		}
-	}()
 
 	u, err := url.JoinPath(client.address, "databases", name, "export")
 	if err != nil {
@@ -424,7 +412,7 @@ func (client *Client) ExportDatabase(name string, file string, opts ...AaliGraph
 		return fmt.Errorf("unexpected status code: %v %q", resp.StatusCode, body)
 	}
 
-	_, err = io.Copy(out, resp.Body)
+	_, err = io.Copy(dst, resp.Body)
 	if err != nil {
 		return err
 	}
@@ -432,18 +420,7 @@ func (client *Client) ExportDatabase(name string, file string, opts ...AaliGraph
 	return nil
 }
 
-func (client *Client) ImportDatabase(name string, filepath string) error {
-	file, err := os.Open(filepath)
-	if err != nil {
-		return nil
-	}
-	defer func() {
-		err := file.Close()
-		if err != nil {
-			client.logger.Warn(fmt.Sprintf("could not close file %q: %s", filepath, err))
-		}
-	}()
-
+func (client *Client) ImportDatabase(name string, src io.Reader) error {
 	u, err := url.JoinPath(client.address, "databases", name, "import")
 	if err != nil {
 		return err
@@ -451,11 +428,11 @@ func (client *Client) ImportDatabase(name string, filepath string) error {
 
 	var b bytes.Buffer
 	w := multipart.NewWriter(&b)
-	fw, err := w.CreateFormFile("file", file.Name())
+	fw, err := w.CreateFormField("file")
 	if err != nil {
 		return err
 	}
-	if _, err = io.Copy(fw, file); err != nil {
+	if _, err = io.Copy(fw, src); err != nil {
 		return nil
 	}
 	if err = w.Close(); err != nil {

--- a/pkg/aali_graphdb/client_test.go
+++ b/pkg/aali_graphdb/client_test.go
@@ -206,6 +206,43 @@ func TestDeleteDatabase(t *testing.T) {
 	assert.Equal(t, []string{}, dbs)
 }
 
+func TestGetSchema(t *testing.T) {
+	client := getTestClient(t)
+
+	const DBNAME = "test-db"
+	err := client.CreateDatabase(DBNAME)
+	require.NoError(t, err)
+
+	for _, query := range []string{
+		"CREATE NODE TABLE User(name STRING, age INT64, PRIMARY KEY (name))",
+		"CREATE NODE TABLE City(name STRING, population INT64, PRIMARY KEY (name))",
+		"CREATE REL TABLE LivesIn(FROM User TO City)",
+	} {
+		_, err := client.CypherQueryWrite(DBNAME, query, nil)
+		require.NoError(t, err)
+	}
+
+	ver, err := client.GetVersion()
+	require.NoError(t, err)
+	schema, err := client.GetSchema(DBNAME)
+	if semverComp(ver.Version, getSchemaMinVer) < 0 {
+		assert.ErrorContains(t, err, "the `GET /databases/{name}/schema` endpoint was introduced in ")
+		assert.Empty(t, schema)
+	} else {
+		assert.NoError(t, err)
+		schemaLines := strings.Split(strings.TrimSpace(schema), "\n")
+		expectedLines := []string{
+			"CREATE NODE TABLE `User` (`name` STRING,`age` INT64, PRIMARY KEY(`name`));",
+			"CREATE NODE TABLE `City` (`name` STRING,`population` INT64, PRIMARY KEY(`name`));",
+			"CREATE REL TABLE `LivesIn` (FROM `User` TO `City`, MANY_MANY);",
+		}
+		assert.Len(t, schemaLines, len(expectedLines))
+		for _, line := range schemaLines {
+			assert.Contains(t, expectedLines, line)
+		}
+	}
+}
+
 func TestReadWriteData(t *testing.T) {
 	client := getTestClient(t)
 	const DBNAME = "my-db"

--- a/pkg/aali_graphdb/client_test.go
+++ b/pkg/aali_graphdb/client_test.go
@@ -35,6 +35,8 @@ import (
 	"os"
 	"path"
 	"regexp"
+	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -43,6 +45,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	"golang.org/x/mod/semver"
 )
 
@@ -141,7 +145,16 @@ func TestGetDatabases(t *testing.T) {
 }
 
 func TestCreateDatabase(t *testing.T) {
+	var warnLogs strings.Builder
+	logger := zap.New(zapcore.NewCore(
+		zapcore.NewConsoleEncoder(zap.NewProductionEncoderConfig()),
+		zapcore.AddSync(&warnLogs),
+		zapcore.WarnLevel,
+	))
+	defer func() { require.NoError(t, logger.Sync()) }()
+
 	client := getTestClient(t)
+	client.logger = logger
 
 	// make sure no dbs
 	dbs, err := client.GetDatabases()
@@ -152,6 +165,17 @@ func TestCreateDatabase(t *testing.T) {
 	const NEWDBNAME = "test-create-db"
 	err = client.CreateDatabase(NEWDBNAME)
 	require.NoError(t, err)
+
+	// check warnings, if appropriate
+	ver, err := client.GetVersion()
+	require.NoError(t, err)
+	if semverComp(ver.Version, createDbPutMinVer) < 0 {
+		logs := strings.Split(strings.TrimSpace(warnLogs.String()), "\n")
+		assert.Len(t, logs, 1)
+		assert.True(t, slices.ContainsFunc(logs, func(log string) bool {
+			return strings.Contains(log, "The `POST /databases` method for creating a new DB is deprecated. Upgrade your aali-graphdb server to use the newer `PUT /databases/{name}` method")
+		}))
+	}
 
 	// now check the dbs again
 	dbs, err = client.GetDatabases()

--- a/pkg/aali_graphdb/client_test.go
+++ b/pkg/aali_graphdb/client_test.go
@@ -24,6 +24,7 @@ package aali_graphdb
 
 import (
 	"archive/tar"
+	"bytes"
 	"compress/gzip"
 	"context"
 	"encoding/json"
@@ -518,29 +519,51 @@ func TestExport(t *testing.T) {
 		"ParquetBest":        {[]AaliGraphDbExportOpt{WithFormatParquet{}, WithCompressionBest{}}, "parquet"},
 		"CsvFast":            {[]AaliGraphDbExportOpt{WithCompressionFast{}, WithFormatCsv{}}, "csv"},
 	}
-	for name, tc := range testCases {
-		t.Run(name, func(t *testing.T) {
+
+	for mode, exportBuilder := range map[string]func(*testing.T) io.ReadWriter{
+		"File": func(t *testing.T) io.ReadWriter {
 			tmpdir := t.TempDir()
-			exportFile := path.Join(tmpdir, "export.tar.gz")
-			require.NoFileExists(t, exportFile)
-			require.NoError(t, client.ExportDatabase(Db, exportFile, tc.opts...))
-			assert.FileExists(t, exportFile)
-
-			unarchivedPath := path.Join(tmpdir, "unarchived")
-			require.NoError(t, os.Mkdir(unarchivedPath, os.ModePerm))
-			archive, err := os.Open(exportFile)
+			exportFile, err := os.CreateTemp(tmpdir, "*.tar.gz")
 			require.NoError(t, err)
-			defer func() { _ = archive.Close() }()
-			require.NoError(t, extractTarGz(archive, unarchivedPath))
+			return exportFile
+		},
+		"Buffer": func(t *testing.T) io.ReadWriter {
+			return &bytes.Buffer{}
+		},
+	} {
+		t.Run(mode, func(t *testing.T) {
+			for name, tc := range testCases {
+				t.Run(name, func(t *testing.T) {
+					export := exportBuilder(t)
 
-			exportDir := path.Join(unarchivedPath, "aali-graphdb-export")
-			assert.DirExists(t, exportDir)
-			assert.FileExists(t, path.Join(exportDir, "copy.cypher"))
-			assert.FileExists(t, path.Join(exportDir, "schema.cypher"))
-			assert.FileExists(t, path.Join(exportDir, "index.cypher"))
-			assert.FileExists(t, path.Join(exportDir, fmt.Sprintf("User.%s", tc.ext)))
+					// close file-like export locations
+					if closer, ok := export.(io.Closer); ok {
+						defer func() { require.NoError(t, closer.Close()) }()
+					}
+					require.NoError(t, client.ExportDatabase(Db, export, tc.opts...))
+
+					// seek back to the start for file-like export locations
+					if seeker, ok := export.(io.Seeker); ok {
+						_, err := seeker.Seek(0, io.SeekStart)
+						require.NoError(t, err)
+					}
+
+					tmpdir := t.TempDir()
+					unarchivedPath := path.Join(tmpdir, "unarchived")
+					require.NoError(t, os.Mkdir(unarchivedPath, os.ModePerm))
+					require.NoError(t, extractTarGz(export, unarchivedPath))
+
+					exportDir := path.Join(unarchivedPath, "aali-graphdb-export")
+					assert.DirExists(t, exportDir)
+					assert.FileExists(t, path.Join(exportDir, "copy.cypher"))
+					assert.FileExists(t, path.Join(exportDir, "schema.cypher"))
+					assert.FileExists(t, path.Join(exportDir, "index.cypher"))
+					assert.FileExists(t, path.Join(exportDir, fmt.Sprintf("User.%s", tc.ext)))
+				})
+			}
 		})
 	}
+
 }
 
 func extractTarGz(r io.Reader, dir string) error {
@@ -598,25 +621,48 @@ func TestImport(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	for name, format := range map[string]AaliGraphDbExportOpt{
-		"Parquet": WithFormatParquet{},
-		"Csv":     WithFormatCsv{},
-	} {
-		t.Run(name, func(t *testing.T) {
+	for mode, exportBuilder := range map[string]func(*testing.T) io.ReadWriter{
+		"File": func(t *testing.T) io.ReadWriter {
 			tmpdir := t.TempDir()
-			export := path.Join(tmpdir, "export.tar.gz")
-			require.NoError(t, client.ExportDatabase(SeedDb, export, format))
-
-			require.NoError(t, client.CreateDatabase(name))
-			resBefore, err := client.CypherQueryRead(name, "MATCH (u) RETURN COUNT(*) AS count;", nil)
+			exportFile, err := os.CreateTemp(tmpdir, "*.tar.gz")
 			require.NoError(t, err)
-			require.Equal(t, 0., resBefore[0]["count"])
+			return exportFile
+		},
+		"Buffer": func(t *testing.T) io.ReadWriter {
+			return &bytes.Buffer{}
+		},
+	} {
+		t.Run(mode, func(t *testing.T) {
+			for name, format := range map[string]AaliGraphDbExportOpt{
+				"Parquet": WithFormatParquet{},
+				"Csv":     WithFormatCsv{},
+			} {
+				t.Run(name, func(t *testing.T) {
+					db := fmt.Sprintf("%s-%s", mode, name)
 
-			require.NoError(t, client.ImportDatabase(name, export))
-			resAfter, err := client.CypherQueryRead(name, "MATCH (u) RETURN COUNT(*) AS count;", nil)
-			require.NoError(t, err)
-			assert.Equal(t, 4., resAfter[0]["count"])
+					export := exportBuilder(t)
+					if closer, ok := export.(io.Closer); ok {
+						// make sure file-like exports are closed at the end
+						defer func() { require.NoError(t, closer.Close()) }()
+					}
+					require.NoError(t, client.ExportDatabase(SeedDb, export, format))
+					if seeker, ok := export.(io.Seeker); ok {
+						// make sure file-like exports are rewinded back to start
+						_, err := seeker.Seek(0, io.SeekStart)
+						require.NoError(t, err)
+					}
+
+					require.NoError(t, client.CreateDatabase(db))
+					resBefore, err := client.CypherQueryRead(db, "MATCH (u) RETURN COUNT(*) AS count;", nil)
+					require.NoError(t, err)
+					require.Equal(t, 0., resBefore[0]["count"])
+
+					require.NoError(t, client.ImportDatabase(db, export))
+					resAfter, err := client.CypherQueryRead(db, "MATCH (u) RETURN COUNT(*) AS count;", nil)
+					require.NoError(t, err)
+					assert.Equal(t, 4., resAfter[0]["count"])
+				})
+			}
 		})
 	}
-
 }

--- a/pkg/aali_graphdb/json.go
+++ b/pkg/aali_graphdb/json.go
@@ -99,12 +99,16 @@ type tagged interface {
 
 // helper type for serializing 2-tuples
 type Twople[A any, B any] struct {
-	a A
-	b B
+	A A
+	B B
+}
+
+func NewTwople[A any, B any](a A, b B) Twople[A, B] {
+	return Twople[A, B]{a, b}
 }
 
 func (tup Twople[A, B]) MarshalJSON() ([]byte, error) {
-	return json.Marshal([]any{tup.a, tup.b})
+	return json.Marshal([]any{tup.A, tup.B})
 }
 
 func (tup *Twople[A, B]) UnmarshalJSON(data []byte) error {
@@ -126,8 +130,8 @@ func (tup *Twople[A, B]) UnmarshalJSON(data []byte) error {
 			return err
 		}
 
-		tup.a = a
-		tup.b = b
+		tup.A = a
+		tup.B = b
 		return nil
 	} else {
 		return fmt.Errorf("cannot unmarshal array of length %d to Twople, must be length 2", len(arr))
@@ -140,29 +144,29 @@ type typedValuesTwople Twople[logicalTypeUnmarshalHelper, valueArrayJson]
 
 func typedValuesTwopleFromList(l listValue) typedValuesTwople {
 	return typedValuesTwople{
-		a: l.LogicalType,
-		b: l.Values,
+		A: l.LogicalType,
+		B: l.Values,
 	}
 }
 
 func (tup typedValuesTwople) toList() listValue {
 	return listValue{
-		LogicalType: tup.a,
-		Values:      tup.b,
+		LogicalType: tup.A,
+		Values:      tup.B,
 	}
 }
 
 func typedValuesTwopleFromArray(a arrayValue) typedValuesTwople {
 	return typedValuesTwople{
-		a: a.LogicalType,
-		b: a.Values,
+		A: a.LogicalType,
+		B: a.Values,
 	}
 }
 
 func (tup typedValuesTwople) toArray() arrayValue {
 	return arrayValue{
-		LogicalType: tup.a,
-		Values:      tup.b,
+		LogicalType: tup.A,
+		Values:      tup.B,
 	}
 }
 
@@ -197,7 +201,7 @@ func namedFieldsTwoplesFromMap(m map[string]Value) namedFieldsTwoples {
 func (t namedFieldsTwoples) toMap() map[string]Value {
 	m := make(map[string]Value, len(t))
 	for _, tup := range t {
-		m[tup.a] = tup.b.Value
+		m[tup.A] = tup.B.Value
 	}
 	return m
 }
@@ -232,7 +236,7 @@ func namedTypesTwoplesFromMap(m map[string]LogicalType) namedTypesTwoples {
 func (t namedTypesTwoples) toMap() map[string]LogicalType {
 	m := make(map[string]LogicalType, len(t))
 	for _, tup := range t {
-		m[tup.a] = tup.b.LogicalType
+		m[tup.A] = tup.B.LogicalType
 	}
 	return m
 }
@@ -301,7 +305,7 @@ func (v *intervalValueJson) UnmarshalJSON(data []byte) error {
 	if err != nil {
 		return err
 	}
-	allNanos := secsNanos.a*1e9 + secsNanos.b
+	allNanos := secsNanos.A*1e9 + secsNanos.B
 	*v = intervalValueJson(time.Duration(allNanos))
 	return nil
 }
@@ -348,7 +352,7 @@ func (v *valueMapJson) UnmarshalJSON(data []byte) error {
 
 	vals := make(map[Value]Value, len(intermediate))
 	for _, val := range intermediate {
-		vals[val.a.Value] = val.b.Value
+		vals[val.A.Value] = val.B.Value
 	}
 	*v = valueMapJson(vals)
 	return nil
@@ -369,9 +373,9 @@ func (v *mapValueJson) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	*v = mapValueJson(mapValue{
-		intermediate.a.a,
-		intermediate.a.b,
-		intermediate.b,
+		intermediate.A.A,
+		intermediate.A.B,
+		intermediate.B,
 	})
 	return nil
 }

--- a/pkg/aali_graphdb/logical_type.go
+++ b/pkg/aali_graphdb/logical_type.go
@@ -404,7 +404,7 @@ func newLogicalTypeHelper(lt LogicalType) logicalTypeUnmarshalHelper {
 func getTwopleLogicalTypeFromHelper(tups []Twople[string, logicalTypeUnmarshalHelper]) []Twople[string, LogicalType] {
 	ltTups := make([]Twople[string, LogicalType], len(tups))
 	for i, tup := range tups {
-		newTup := Twople[string, LogicalType]{tup.a, tup.b.LogicalType}
+		newTup := Twople[string, LogicalType]{tup.A, tup.B.LogicalType}
 		ltTups[i] = newTup
 	}
 	return ltTups


### PR DESCRIPTION
This makes a few improvements to the aali-graphdb client, mostly to support data-shield improvements.

1. in the import & export functions, instead of accepting a filepath, make them accept io.Reader/io.Writer respectively, so that caller can choose whether it goes to a file or a buffer or something else.
2. Add a method for the corresponding `PUT /databases/{name}` endpoint
3. Add a method for the corresponding `GET /databases/{name}/schema` endpoint